### PR TITLE
feat: expose method to allow setting advertising uuids

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ const wifiListEvent = eventEmitter.addListener(
 type AwsFreertosType = {
   startScanBtDevices(): void;
   stopScanBtDevices(): void;
+  setAdvertisingServiceUUIDs(uuids: string[]): void;
   requestBtPermissions(): Promise<any>;
   connectDevice(macAddress: string): Promise<any>;
   disconnectDevice(macAddress: string): Promise<any>;

--- a/android/src/main/java/com/reactnativeawsfreertos/AwsFreertosModule.kt
+++ b/android/src/main/java/com/reactnativeawsfreertos/AwsFreertosModule.kt
@@ -5,12 +5,14 @@ import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothGattCallback
 import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.le.ScanFilter
 import android.bluetooth.le.ScanResult
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.os.ParcelUuid
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat.requestPermissions
@@ -45,6 +47,19 @@ class AwsFreertosModule(reactContext: ReactApplicationContext) : ReactContextBas
         }
       }
     }
+  }
+
+  @ReactMethod
+  fun setAdvertisingServiceUUIDs(uuids: ReadableArray) {
+    val filters = ArrayList<ScanFilter>()
+    for (uuid in uuids.toArrayList()) {
+      val scanFilter = ScanFilter.Builder()
+        .setServiceUuid(ParcelUuid.fromString(uuid.toString()))
+        .build()
+      filters.add(scanFilter)
+    }
+    val mAmazonFreeRTOSManager = AmazonFreeRTOSAgent.getAmazonFreeRTOSManager(currentActivity);
+    mAmazonFreeRTOSManager.setScanFilters(filters.toList())
   }
 
   @ReactMethod

--- a/ios/AwsFreertos.m
+++ b/ios/AwsFreertos.m
@@ -53,4 +53,7 @@ RCT_EXTERN_METHOD(getConnectedDeviceAvailableNetworks:
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(setAdvertisingServiceUUIDs:
+                  (NSArray *)uuids)
+
 @end

--- a/ios/AwsFreertos.swift
+++ b/ios/AwsFreertos.swift
@@ -40,6 +40,13 @@ class AwsFreertos: RCTEventEmitter {
             EventsEnum.DID_UPDATE_BLE_POWER_STATE
         ];
     }
+    
+    @objc(setAdvertisingServiceUUIDs:)
+    func setAdvertisingServiceUUIDs(_ uuids: Array<String>) -> Void {
+        let bleUuids : Array<CBUUID> = uuids.map { CBUUID (string: $0) }
+        
+        AmazonFreeRTOSManager.shared.advertisingServiceUUIDs = bleUuids
+    }
 
     @objc(requestBtPermissions:withRejecter:)
     func requestBtPermissions(_ resolve:RCTPromiseResolveBlock,withRejecter reject:RCTPromiseRejectBlock) -> Void {

--- a/ios/AwsFreertos.swift
+++ b/ios/AwsFreertos.swift
@@ -146,7 +146,7 @@ class AwsFreertos: RCTEventEmitter {
         self.sendEvent(withName:EventsEnum.DID_FAIL_TO_CONNECT_DEVICE, body: "FAIL");
     }
 
-    @objc(didSaveNetwork)
+    @objc(didSaveNetwork:)
     func didSaveNetwork(_ notification: Notification) -> Void {
         if let saveNetworkResp = notification.userInfo?["saveNetworkResp"] as? SaveNetworkResp {
             if saveNetworkResp.status != NetworkOpStatus.success {

--- a/ios/AwsFreertos.swift
+++ b/ios/AwsFreertos.swift
@@ -119,7 +119,7 @@ class AwsFreertos: RCTEventEmitter {
         }
     }
 
-    @objc(didEditNetwork)
+    @objc(didEditNetwork:)
     func didEditNetwork(_ notification: Notification) -> Void {
         if let saveNetworkResp = notification.userInfo?["saveNetworkResp"] as? SaveNetworkResp {
             if saveNetworkResp.status != NetworkOpStatus.success {
@@ -130,7 +130,7 @@ class AwsFreertos: RCTEventEmitter {
         }
     }
 
-    @objc(didDeleteNetwork)
+    @objc(didDeleteNetwork:)
     func didDeleteNetwork(_ notification: Notification) -> Void {
         if let saveNetworkResp = notification.userInfo?["saveNetworkResp"] as? SaveNetworkResp {
             if saveNetworkResp.status != NetworkOpStatus.success {


### PR DESCRIPTION
This is a feature which allows for setting the advertising UUID's in both iOS and android. It appears that at some point aws freertos stopped allowing blanket advertising uuids and instead the filtering became a must.  Without the ability to set them to scan for specific UUID's we are unable to locate specific devices.

Usage is as simple as modifying the `App.tsx` in the example to run the following before rendering:

```
  AwsFreertos.setAdvertisingServiceUUIDs([
    "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
    "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
  ])
```

Replacing the X's with specific UUID's which will set the filtering of the SDK.